### PR TITLE
check requested error to be positive

### DIFF
--- a/R-proj/src/volume.cpp
+++ b/R-proj/src/volume.cpp
@@ -171,6 +171,9 @@ double volume (Rcpp::Reference P,  Rcpp::Nullable<unsigned int> walk_step = R_Ni
         } else {
             e = Rcpp::as<NT>(error);
         }
+        if (e<=0) {
+            throw Rcpp::exception("The requested error must be positive!");
+        }
 
     } else if (Rcpp::as<std::string>(Algo).compare(std::string("CG"))==0) {
 
@@ -180,6 +183,9 @@ double volume (Rcpp::Reference P,  Rcpp::Nullable<unsigned int> walk_step = R_Ni
             e = 0.1;
         } else {
             e = Rcpp::as<NT>(error);
+        }
+        if (e<=0) {
+            throw Rcpp::exception("The requested error must be positive!");
         }
 
         if (!walk_step.isNotNull()) {


### PR DESCRIPTION
We check the input error in volume function in /R-proj/src/volume.cpp to be positive, otherwise we issue an error and terminate running.
In /test/vol.cpp we perform the same check for the C++ part of the code.

p.s. solve the issue reported in https://github.com/GeomScale/volume_approximation/issues/8 