### PR TITLE
add boundary sampler using Hit-and-Run

### DIFF
--- a/R-proj/src/sample_points.cpp
+++ b/R-proj/src/sample_points.cpp
@@ -79,6 +79,7 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
                                   Rcpp::Nullable<std::string> WalkType = R_NilValue,
                                   Rcpp::Nullable<unsigned int> walk_step = R_NilValue,
                                   Rcpp::Nullable<bool> exact = R_NilValue,
+                                  Rcpp::Nullable<bool> boundary = R_NilValue,
                                   Rcpp::Nullable<std::string> body = R_NilValue,
                                   Rcpp::Nullable<Rcpp::List> Parameters = R_NilValue,
                                   Rcpp::Nullable<Rcpp::NumericVector> InnerPoint = R_NilValue){
@@ -296,25 +297,46 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
         vars_g<NT, RNGType> var2(dim, walkL, 0, 0, 1, 0, InnerBall.second, rng, 0, 0, 0, delta, false, verbose,
                                  rand_only, false, NN, birk, ball_walk, cdhr, rdhr);
 
+        if (boundary.isNotNull() && Rcpp::as<bool>(boundary)) {
+            if (ball_walk) {
+                throw Rcpp::exception("Only Hit-an-Run can be used for boundary sampling!");
+            }
+        }
         switch (type) {
             case 1: {
-                sampling_only<Point>(randPoints, HP, walkL, numpoints, gaussian,
-                                     a, MeanPoint, var1, var2);
+                if (boundary.isNotNull() && Rcpp::as<bool>(boundary)) {
+                    boundary_rand_point_generator(HP, MeanPoint, numpoints / 2, walkL, randPoints, var1);
+                } else {
+                    sampling_only<Point>(randPoints, HP, walkL, numpoints, gaussian,
+                                         a, MeanPoint, var1, var2);
+                }
                 break;
             }
             case 2: {
-                sampling_only<Point>(randPoints, VP, walkL, numpoints, gaussian,
-                                     a, MeanPoint, var1, var2);
+                if (boundary.isNotNull() && Rcpp::as<bool>(boundary)) {
+                    boundary_rand_point_generator(VP, MeanPoint, numpoints / 2, walkL, randPoints, var1);
+                } else {
+                    sampling_only<Point>(randPoints, VP, walkL, numpoints, gaussian,
+                                         a, MeanPoint, var1, var2);
+                }
                 break;
             }
             case 3: {
-                sampling_only<Point>(randPoints, ZP, walkL, numpoints, gaussian,
-                                     a, MeanPoint, var1, var2);
+                if (boundary.isNotNull() && Rcpp::as<bool>(boundary)) {
+                    boundary_rand_point_generator(ZP, MeanPoint, numpoints / 2, walkL, randPoints, var1);
+                } else {
+                    sampling_only<Point>(randPoints, ZP, walkL, numpoints, gaussian,
+                                         a, MeanPoint, var1, var2);
+                }
                 break;
             }
             case 4: {
-                sampling_only<Point>(randPoints, VPcVP, walkL, numpoints, gaussian,
-                                     a, MeanPoint, var1, var2);
+                if (boundary.isNotNull() && Rcpp::as<bool>(boundary)) {
+                    boundary_rand_point_generator(VPcVP, MeanPoint, numpoints / 2, walkL, randPoints, var1);
+                } else {
+                    sampling_only<Point>(randPoints, VPcVP, walkL, numpoints, gaussian,
+                                         a, MeanPoint, var1, var2);
+                }
                 break;
             }
         }

--- a/test/vol.cpp
+++ b/test/vol.cpp
@@ -74,6 +74,7 @@ int main(const int argc, const char** argv)
          Zono=false,
          cdhr=true,
          rdhr=false,
+         boundary = false,
          exact_zono = false,
          gaussian_sam = false;
 
@@ -155,6 +156,12 @@ int main(const int argc, const char** argv)
       if(!strcmp(argv[i],"-rand")||!strcmp(argv[i],"--rand_only")){
           rand_only = true;
           std::cout<<"Generate random points only\n";
+          correct = true;
+      }
+      if(!strcmp(argv[i],"-boundary")){
+          boundary = true;
+          rand_only = true;
+          std::cout<<"Generate random points on the boundary only\n";
           correct = true;
       }
       if(!strcmp(argv[i],"-rdhr")){
@@ -446,11 +453,23 @@ int main(const int argc, const char** argv)
 
       double tstart11 = (double)clock()/(double)CLOCKS_PER_SEC;
       if (Zono) {
-          sampling_only<Point>(randPoints, ZP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          if (boundary) {
+              boundary_rand_point_generator(ZP, InnerBall.first, nsam, walk_len, randPoints, var1);
+          } else {
+              sampling_only<Point>(randPoints, ZP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          }
       } else if (!Vpoly) {
-          sampling_only<Point>(randPoints, HP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          if (boundary) {
+              boundary_rand_point_generator(HP, InnerBall.first, nsam, walk_len, randPoints, var1);
+          } else {
+              sampling_only<Point>(randPoints, HP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          }
       } else {
-          sampling_only<Point>(randPoints, VP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          if (boundary) {
+              boundary_rand_point_generator(VP, InnerBall.first, nsam, walk_len, randPoints, var1);
+          } else {
+              sampling_only<Point>(randPoints, VP, walk_len, nsam, gaussian_sam, a, InnerBall.first, var1, var2);
+          }
       }
       double tstop11 = (double)clock()/(double)CLOCKS_PER_SEC;
       if(verbose) std::cout << "Sampling time: " << tstop11 - tstart11 << std::endl;


### PR DESCRIPTION
In /include/samplers/samplers.h we implement function 'void boundary_rand_point_generator()' in order to sample from the boundary of a convex polytope.

We use Hit-and-Run and we store the extreme points in every step of the walk.

We export the function through Rcpp function `sample_points()` in `sample_points.cpp`. 
You can request for boundary sampling when the flag `boundary=TRUE`

You can use the flag `-boundary` in C++ interface (vol.cpp) to request boundary sampling.