### PR TITLE
Implement Dikin walk

### DIFF
--- a/R-proj/src/rounding.cpp
+++ b/R-proj/src/rounding.cpp
@@ -56,7 +56,7 @@ Rcpp::List rounding (Rcpp::Reference P,
             NN=false,
             birk=false,
             verbose=false,
-            cdhr=true, rdhr = false, ball_walk = false;
+            cdhr=true, rdhr = false, ball_walk = false, dikin = false;
     NT delta = -1.0;
 
     unsigned int n = P.field("dimension");
@@ -93,10 +93,12 @@ Rcpp::List rounding (Rcpp::Reference P,
         cdhr = true;
         rdhr = false;
         ball_walk = false;
+        dikin = false;
     } else if (Rcpp::as<std::string>(WalkType).compare(std::string("RDHR"))==0) {
         cdhr = false;
         rdhr = true;
         ball_walk = false;
+        dikin = false;
     } else if (Rcpp::as<std::string>(WalkType).compare(std::string("BW"))==0) {
         if(radius.isNotNull()){
             delta = Rcpp::as<NT>(radius);
@@ -106,7 +108,13 @@ Rcpp::List rounding (Rcpp::Reference P,
         cdhr = false;
         rdhr = false;
         ball_walk = true;
-    } else {
+        dikin = false;
+    }else if (Rcpp::as<std::string>(WalkType).compare(std::string("Dikin"))==0) {
+        cdhr = false;
+        rdhr = false;
+        ball_walk = false;
+        dikin = true;
+    }else {
         throw Rcpp::exception("Unknown walk type!");
     }
 
@@ -118,7 +126,7 @@ Rcpp::List rounding (Rcpp::Reference P,
 
     // initialization
     vars<NT, RNGType> var(rnum,n,walkL,1,0.0,0.0,0,0.0,0,InnerBall.second,rng,urdist,urdist1,
-                          delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr);
+                          delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr,dikin);
     std::pair <NT, NT> round_res;
 
     switch (type) {

--- a/R-proj/src/sample_points.cpp
+++ b/R-proj/src/sample_points.cpp
@@ -101,7 +101,7 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
 
     int type, dim, numpoints;
     NT radius = 1.0, delta = -1.0;
-    bool set_mean_point = false, cdhr = true, rdhr = false, ball_walk = false, gaussian = false;
+    bool set_mean_point = false, cdhr = true, rdhr = false, ball_walk = false, gaussian = false, dikin = false;
     std::list<Point> randPoints;
     std::pair<Point, NT> InnerBall;
 
@@ -196,10 +196,12 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
             cdhr = true;
             rdhr = false;
             ball_walk = false;
+            dikin = false;
         } else if (Rcpp::as<std::string>(WalkType).compare(std::string("RDHR"))==0) {
             cdhr = false;
             rdhr = true;
             ball_walk = false;
+            dikin = false;
         } else if (Rcpp::as<std::string>(WalkType).compare(std::string("BW"))==0) {
             if (Rcpp::as<Rcpp::List>(Parameters).containsElementNamed("BW_rad")) {
                 delta = Rcpp::as<NT>(Rcpp::as<Rcpp::List>(Parameters)["BW_rad"]);
@@ -207,6 +209,12 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
             cdhr = false;
             rdhr = false;
             ball_walk = true;
+            dikin = false;
+        }else if (Rcpp::as<std::string>(WalkType).compare(std::string("Dikin"))==0) {
+            cdhr = false;
+            rdhr = false;
+            ball_walk = false;
+            dikin = true;
         } else {
             throw Rcpp::exception("Unknown walk type!");
         }
@@ -292,9 +300,9 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
             }
         }
         vars<NT, RNGType> var1(1,dim,walkL,1,0.0,0.0,0,0.0,0,InnerBall.second,rng,urdist,urdist1,
-                               delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr);
+                               delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr,dikin);
         vars_g<NT, RNGType> var2(dim, walkL, 0, 0, 1, 0, InnerBall.second, rng, 0, 0, 0, delta, false, verbose,
-                                 rand_only, false, NN, birk, ball_walk, cdhr, rdhr);
+                                 rand_only, false, NN, birk, ball_walk, cdhr, rdhr,dikin);
 
         switch (type) {
             case 1: {

--- a/R-proj/src/sample_points.cpp
+++ b/R-proj/src/sample_points.cpp
@@ -237,6 +237,12 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
         boost::random::uniform_real_distribution<>(urdist);
         boost::random::uniform_real_distribution<> urdist1(-1,1);
 
+        if (dikin) {
+            if (type != 1) {
+                throw Rcpp::exception("Dikin walk can be used only for H-polytopes!");
+            }
+            HP.set_dikin_rep();
+        }
         switch(type) {
             case 1: {
                 // Hpolytope

--- a/include/convex_bodies/polytopes.h
+++ b/include/convex_bodies/polytopes.h
@@ -402,6 +402,31 @@ public:
     }
 
 
+    void set_dikin_rep() {
+        for (int i = 0; i < A.rows(); ++i) {
+            A.row(i) = A.row(i) * (1.0/b(i));
+            b(i) = 1.0;
+        }
+    }
+
+
+    MT get_Dikin_ell(Point &x) {
+        MT H= MT::Zero(_d,_d);
+        VT r(_d);
+        NT sum;
+        for (int i = 0; i < A.rows(); ++i) {
+            for (int k = 0; k < _d; ++k) {
+                r(k) = A(i,k);
+            }
+            sum = 1.0;
+            for (int j = 0; j < _d; ++j) {
+                sum -= r(j)*x[j];
+            }
+            H = H + (r*r.transpose())*(1.0/(sum*sum));
+        }
+        return H;
+    }
+
     // return for each facet the distance from the origin
     std::vector<NT> get_dists(NT radius){
         unsigned int i=0;
@@ -768,6 +793,14 @@ public:
         }
         return true;
     }
+
+    void set_dikin_rep() {
+
+    }
+
+    MT get_Dikin_ell(Point &x) {
+        return V;
+    }
 };
 
 
@@ -1021,6 +1054,14 @@ public:
     template <class T>
     bool get_points_for_rounding (T &randPoints) {
         return false;
+    }
+
+    void set_dikin_rep() {
+
+    }
+
+    MT get_Dikin_ell(Point &x) {
+        return V;
     }
 
 };

--- a/include/convex_bodies/vpolyintersectvpoly.h
+++ b/include/convex_bodies/vpolyintersectvpoly.h
@@ -275,6 +275,14 @@ public:
         return true;
     }
 
+    void set_dikin_rep() {
+
+    }
+
+    MT get_Dikin_ell(Point &x) {
+        return P1.get_mat();
+    }
+
 };
 
 

--- a/include/samplers/samplers.h
+++ b/include/samplers/samplers.h
@@ -71,6 +71,49 @@ void ball_walk(Point &p,
     if (P.is_in(y)==-1) p = y;
 }
 
+template <class MT, class Point>
+bool is_in_ell(MT &H, Point &center, Point &p) {
+
+    typedef typename Point::FT NT;
+    Point x = p-center;
+    unsigned int dim = center.dimension();
+    NT sum, mults =0.0;
+
+    for (int i = 0; i < dim; ++i) {
+        sum = 0.0;
+        for (int j = 0; j < dim; ++j) {
+            sum += H(i,j)*x[j];
+        }
+        mults += sum * x[i];
+    }
+
+    if (mults < 1.0) {
+        return true;
+    }
+    return false;
+
+}
+
+template <class RNGType, class Polytope, class Point>
+void Dikin_walk(Point &p, Polytope &P) {
+
+    typedef typename Point::FT NT;
+    typedef typename Polytope::MT MT;
+    boost::random::uniform_real_distribution<> urdist(0,1);
+    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+    RNGType rng2(seed);
+    //if (urdist(rng2)<0.5) return;
+    MT Hp = P.get_Dikin_ell(p);
+    Point q = get_point_in_ellipsoid<RNGType>(Hp, p);
+    MT Hq = P.get_Dikin_ell(q);
+    if (is_in_ell(Hq, q, p)) {
+        if (urdist(rng2)<std::min(1.0, std::sqrt(Hq.determinant() / Hp.determinant()))){
+            p=q;
+        }
+    }
+    //return p;
+}
+
 // WARNING: USE ONLY WITH BIRKHOFF POLYOPES
 // Compute more random points using symmetries of birkhoff polytope
 /*

--- a/include/volume/vars.h
+++ b/include/volume/vars.h
@@ -38,12 +38,13 @@ public:
           bool birk,
           bool ball_walk,
           bool cdhr_walk,
-          bool rdhr_walk
+          bool rdhr_walk,
+          bool dikin_walk
     ) :
             m(m), n(n), walk_steps(walk_steps), n_threads(n_threads), err(err), error(error),
-            lw(lw), up(up), L(L), che_rad(che_rad), rng(rng),
-            urdist(urdist), urdist1(urdist1) , delta(delta) , verbose(verbose), rand_only(rand_only), round(round),
-            NN(NN),birk(birk), ball_walk(ball_walk), cdhr_walk(cdhr_walk), rdhr_walk(rdhr_walk){};
+            lw(lw), up(up), L(L), che_rad(che_rad), rng(rng), urdist(urdist), urdist1(urdist1), delta(delta),
+            verbose(verbose), rand_only(rand_only), round(round), NN(NN),birk(birk), ball_walk(ball_walk),
+            cdhr_walk(cdhr_walk), rdhr_walk(rdhr_walk), dikin_walk(dikin_walk){};
 
     unsigned int m;
     unsigned int n;
@@ -67,6 +68,7 @@ public:
     bool ball_walk;
     bool cdhr_walk;
     bool rdhr_walk;
+    bool dikin_walk;
 };
 
 template <typename NT, class RNG>
@@ -93,12 +95,13 @@ public:
            bool birk,
            bool ball_walk,
            bool cdhr_walk,
-           bool rdhr_walk
+           bool rdhr_walk,
+           bool dikin_walk
     ) :
             n(n), walk_steps(walk_steps), N(N), W(W), n_threads(n_threads), error(error),
             che_rad(che_rad), rng(rng), C(C), frac(frac), ratio(ratio), delta(delta),
             deltaset(deltaset), verbose(verbose), rand_only(rand_only), round(round),
-            NN(NN),birk(birk),ball_walk(ball_walk),cdhr_walk(cdhr_walk), rdhr_walk(rdhr_walk){};
+            NN(NN),birk(birk),ball_walk(ball_walk),cdhr_walk(cdhr_walk), rdhr_walk(rdhr_walk), dikin_walk(dikin_walk){};
 
     unsigned int n;
     unsigned int walk_steps;
@@ -121,6 +124,7 @@ public:
     bool ball_walk;
     bool cdhr_walk;
     bool rdhr_walk;
+    bool dikin_walk;
 };
 
 #endif

--- a/test/VpolyCV_test.cpp
+++ b/test/VpolyCV_test.cpp
@@ -52,9 +52,9 @@ void test_CV_volume(Polytope &VP, NT expected, NT tolerance=0.25)
     {
         CheBall = VP.ComputeInnerBall();
         vars<NT, RNGType> var2(rnum,n,10 + n/10,n_threads,err,e,0,0,0,0,rng,
-                               urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                               urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
         vars_g<NT, RNGType> var1(n,walk_len,N,W,1,e,CheBall.second,rng,C,frac,ratio,delta,false,
-                                 false,false,false,false,false,false,true,false);
+                                 false,false,false,false,false,false,true,false,false);
         vol += volume_gaussian_annealing(VP, var1, var2, CheBall);
 
     }

--- a/test/VpolyVol_test.cpp
+++ b/test/VpolyVol_test.cpp
@@ -37,7 +37,7 @@ void test_volume(Polytope &VP, NT expected, NT tolerance=0.1)
     boost::random::uniform_real_distribution<> urdist1(-1,1);
 
     vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
 
     //Compute chebychev ball//
     std::pair<Point,NT> CheBall;

--- a/test/ZonotopeVolCV_test.cpp
+++ b/test/ZonotopeVolCV_test.cpp
@@ -45,7 +45,7 @@ void test_zono_volume(int n, int m, NT tolerance = 0.3)
     std::pair<NT,NT> res_round;
 
     vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
 
     //Compute chebychev ball//
     std::pair<Point,NT> CheBall;
@@ -63,9 +63,9 @@ void test_zono_volume(int n, int m, NT tolerance = 0.3)
     {
         CheBall = ZP.ComputeInnerBall();
         vars<NT, RNGType> var2(rnum,n,10 + n/10,n_threads,err,e,0,0,0,0,rng,
-                               urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                               urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
         vars_g<NT, RNGType> var1(n,walk_len,N,W,1,e,CheBall.second,rng,C,frac,ratio,delta,false,
-                                 false,false,false,false,false,false,true,false);
+                                 false,false,false,false,false,false,true,false,false);
         vol += volume_gaussian_annealing(ZP, var1, var2, CheBall);
     }
     NT error = std::abs(((vol/num_of_exp)-vol_exact))/vol_exact;

--- a/test/ZonotopeVol_test.cpp
+++ b/test/ZonotopeVol_test.cpp
@@ -40,7 +40,7 @@ void test_zono_volume(int n, int m, NT tolerance = 0.15)
     std::pair<NT,NT> res_round;
 
     vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                          urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
 
     //Compute chebychev ball//
     std::pair<Point,NT> CheBall;

--- a/test/chebychev_test.cpp
+++ b/test/chebychev_test.cpp
@@ -37,7 +37,7 @@ void cheb_test(Polytope &P, NT expected, NT tolerance=0.0001)
     boost::random::uniform_real_distribution<> urdist1(-1,1);
 
     vars<NT,RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-             urdist,urdist1,-1.0,false,false,false,false,false,false,true, false);
+             urdist,urdist1,-1.0,false,false,false,false,false,false,true, false,false);
 
     //Compute chebychev ball//
     //std::cout << "\n--- Testing Chebchev ball computation of " << f << std::endl;

--- a/test/rounding_test.cpp
+++ b/test/rounding_test.cpp
@@ -36,7 +36,7 @@ void rounding_test(Polytope &P, bool rot, NT expected, NT tolerance=0.2)
     boost::random::uniform_real_distribution<>(urdist);
     boost::random::uniform_real_distribution<> urdist1(-1,1);
     vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
 
     std::cout << "Number type: " << typeid(NT).name() << std::endl;
     //apply rotation if requested

--- a/test/vol.cpp
+++ b/test/vol.cpp
@@ -74,6 +74,7 @@ int main(const int argc, const char** argv)
          Zono=false,
          cdhr=true,
          rdhr=false,
+         dikin=false,
          exact_zono = false,
          gaussian_sam = false;
 
@@ -167,6 +168,13 @@ int main(const int argc, const char** argv)
           ball_walk = true;
           cdhr = false;
           rdhr = false;
+          correct = true;
+      }
+      if(!strcmp(argv[i],"-dikin")){
+          ball_walk = true;
+          cdhr = false;
+          rdhr = false;
+          dikin = true;
           correct = true;
       }
       if(!strcmp(argv[i],"-bwr")){
@@ -440,9 +448,9 @@ int main(const int argc, const char** argv)
           }
       }
       vars<NT, RNGType> var1(0, n, walk_len, 1, 0, 0, 0, 0.0, 0, InnerBall.second, rng,
-                urdist, urdist1, delta, verbose, rand_only, round, NN, birk, ball_walk, cdhr, rdhr);
+                urdist, urdist1, delta, verbose, rand_only, round, NN, birk, ball_walk, cdhr, rdhr, dikin);
       vars_g<NT, RNGType> var2(n, walk_len, N, W, 1, 0, InnerBall.second, rng, C, frac, ratio, delta,
-                  false, verbose, rand_only, round, NN, birk, ball_walk, cdhr, rdhr);
+                  false, verbose, rand_only, round, NN, birk, ball_walk, cdhr, rdhr, dikin);
 
       double tstart11 = (double)clock()/(double)CLOCKS_PER_SEC;
       if (Zono) {
@@ -475,7 +483,7 @@ int main(const int argc, const char** argv)
 
       // Setup the parameters
       vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0.0,0,InnerBall.second,rng,
-               urdist,urdist1,delta,verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr);
+               urdist,urdist1,delta,verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr, false);
 
       if(round_only) {
           // Round the polytope and exit
@@ -501,10 +509,10 @@ int main(const int argc, const char** argv)
 
               // setup the parameters
               vars<NT, RNGType> var2(rnum,n,10 + n/10,n_threads,err,e,0,0.0,0,InnerBall.second,rng,
-                       urdist,urdist1,delta,verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr);
+                       urdist,urdist1,delta,verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr,false);
 
               vars_g<NT, RNGType> var1(n,walk_len,N,W,1,error,InnerBall.second,rng,C,frac,ratio,delta,false,
-                          verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr);
+                          verbose,rand_only,round,NN,birk,ball_walk,cdhr,rdhr,false);
 
               if (Zono) {
                   vol = volume_gaussian_annealing(ZP, var1, var2, InnerBall);

--- a/test/volumeCV_test.cpp
+++ b/test/volumeCV_test.cpp
@@ -54,9 +54,9 @@ void test_CV_volume(Polytope &HP, NT expected, NT tolerance=0.3)
     {
         CheBall = HP.ComputeInnerBall();
         vars<NT, RNGType> var2(rnum,n,10 + n/10,n_threads,err,e,0,0,0,0,rng,
-                 urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+                 urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
         vars_g<NT, RNGType> var1(n,walk_len,N,W,1,e,CheBall.second,rng,C,frac,ratio,delta,false,
-                    false,false,false,false,false,false,true,false);
+                    false,false,false,false,false,false,true,false,false);
         vol += volume_gaussian_annealing(HP, var1, var2, CheBall);
     }
     NT error = std::abs(((vol/num_of_exp)-expected))/expected;

--- a/test/volume_example.cpp
+++ b/test/volume_example.cpp
@@ -78,9 +78,9 @@ int main()
     boost::random::uniform_real_distribution<> urdist1(-1,1);
     
     vars<NT, RNGType> var1(rnum,n,walk_len,1,0,1,0,0,0,0,rng,
-             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
     vars_g<NT, RNGType> var2(n,walk_len,N,W,1,0.2,CheBall.second,rng,C,0.1,ratio,-1,false,
-                    false,false,false,false,false,false,true,false);
+                    false,false,false,false,false,false,true,false,false);
 
     // Estimate the volume
     NT vol1 = volume(HP, var1, CheBall);

--- a/test/volume_test.cpp
+++ b/test/volume_test.cpp
@@ -38,7 +38,7 @@ void test_volume(Polytope &HP, NT expected, NT tolerance=0.1)
     boost::random::uniform_real_distribution<> urdist1(-1,1);
     
     vars<NT, RNGType> var(rnum,n,walk_len,n_threads,err,e,0,0,0,0,rng,
-             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false);
+             urdist,urdist1,-1.0,false,false,false,false,false,false,true,false,false);
 
     //Compute chebychev ball//
     std::pair<Point,NT> CheBall;


### PR DESCRIPTION
Implement Dikin walk for H-polytopes. For V-polytopes and zonotopes the walk is undefined. 

The walk can be used only for uniform sampling. For volume computation we issue a warning and use Hit-and-Run. 

We expose the implementation in R through Rcpp functtion `sample_points()` in `/R-proj/src/sample_points.cpp`. It is requested when `WalkType = "Dikin" `

The flag `-dikin` can be used in C++ interface (vol.cpp) to request Dikin walk.