### PR TITLE
Volume computation and sampling for low dimensional convex polytopes

### DIFF
--- a/R-proj/R/RcppExports.R
+++ b/R-proj/R/RcppExports.R
@@ -223,8 +223,8 @@ rounding <- function(P, WalkType = NULL, walk_step = NULL, radius = NULL) {
 #' P = Vpolytope$new(V)
 #' points = sample_points(P, N = 10000, exact = TRUE)
 #' @export
-sample_points <- function(P = NULL, N = NULL, distribution = NULL, WalkType = NULL, walk_step = NULL, exact = NULL, body = NULL, Parameters = NULL, InnerPoint = NULL) {
-    .Call(`_volesti_sample_points`, P, N, distribution, WalkType, walk_step, exact, body, Parameters, InnerPoint)
+sample_points <- function(P = NULL, N = NULL, distribution = NULL, WalkType = NULL, walk_step = NULL, exact = NULL, body = NULL, Parameters = NULL, InnerPoint = NULL, A = NULL, b = NULL, Aeq = NULL, beq = NULL) {
+    .Call(`_volesti_sample_points`, P, N, distribution, WalkType, walk_step, exact, body, Parameters, InnerPoint, A, b, Aeq, beq)
 }
 
 #' The main function for volume approximation of a convex Polytope (H-polytope, V-polytope or a zonotope)
@@ -267,7 +267,7 @@ sample_points <- function(P = NULL, N = NULL, distribution = NULL, WalkType = NU
 #' Z = GenZonotope(2, 4)
 #' vol = volume(Z, WalkType = "RDHR", walk_step = 5)
 #' @export
-volume <- function(P, walk_step = NULL, error = NULL, InnerBall = NULL, Algo = NULL, WalkType = NULL, rounding = NULL, Parameters = NULL) {
-    .Call(`_volesti_volume`, P, walk_step, error, InnerBall, Algo, WalkType, rounding, Parameters)
+volume <- function(P = NULL, walk_step = NULL, error = NULL, InnerBall = NULL, Algo = NULL, WalkType = NULL, rounding = NULL, Parameters = NULL, A = NULL, b = NULL, Aeq = NULL, beq = NULL) {
+    .Call(`_volesti_volume`, P, walk_step, error, InnerBall, Algo, WalkType, rounding, Parameters, A, b, Aeq, beq)
 }
 

--- a/R-proj/src/sample_points.cpp
+++ b/R-proj/src/sample_points.cpp
@@ -257,6 +257,9 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
             if (!feas) {
                 Rf_warning("The region is not feasible!");
                 return Rcpp::NumericMatrix();
+            } else if (gaussian) {
+                Rf_warning("The region is feasible but Gaussian sampling is not available for low dimensional convex polytopes.");
+                return Rcpp::NumericMatrix();
             }
             Hpolytope HP2;
             std::pair<Hpolytope ,VT> low_res;
@@ -273,7 +276,7 @@ Rcpp::NumericMatrix sample_points(Rcpp::Nullable<Rcpp::Reference> P = R_NilValue
             }
             InnerBall = HP2.ComputeInnerBall();
             vars<NT, RNGType> var1(1,dim,walkL,1,0.0,0.0,0,0.0,0,InnerBall.second,rng,urdist,urdist1,
-                                   delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr, dikin);
+                                   delta,verbose,rand_only,false,NN,birk,ball_walk,cdhr,rdhr);
             Point p = InnerBall.first;
             std::list<Point> randPoints2;
             rand_point_generator(HP2, p, numpoints, walkL, randPoints2, var1);

--- a/R-proj/src/volume.cpp
+++ b/R-proj/src/volume.cpp
@@ -10,6 +10,7 @@
 #include <Rcpp.h>
 #include <RcppEigen.h>
 #include "volume.h"
+#include "low_dimensional.h"
 
 
 template <class Point, class NT, class Polytope>
@@ -110,16 +111,18 @@ double generic_volume(Polytope& P, unsigned int walk_step, double e,
 //' vol = volume(Z, WalkType = "RDHR", walk_step = 5)
 //' @export
 // [[Rcpp::export]]
-double volume (Rcpp::Reference P,  Rcpp::Nullable<unsigned int> walk_step = R_NilValue,
-                Rcpp::Nullable<double> error = R_NilValue,
-                Rcpp::Nullable<Rcpp::NumericVector> InnerBall = R_NilValue,
-                Rcpp::Nullable<std::string> Algo = R_NilValue,
-                Rcpp::Nullable<std::string> WalkType = R_NilValue, Rcpp::Nullable<bool> rounding = R_NilValue,
-                Rcpp::Nullable<Rcpp::List> Parameters = R_NilValue,
-                Rcpp::Nullable<Rcpp::NumericMatrix> A = R_NilValue,
-                Rcpp::Nullable<Rcpp::NumericVector> b = R_NilValue,
-                Rcpp::Nullable<Rcpp::NumericMatrix> Aeq = R_NilValue,
-                Rcpp::Nullable<Rcpp::NumericVector> beq = R_NilValue) {
+double volume (Rcpp::Nullable<Rcpp::Reference> P = R_NilValue,
+               Rcpp::Nullable<unsigned int> walk_step = R_NilValue,
+               Rcpp::Nullable<double> error = R_NilValue,
+               Rcpp::Nullable<Rcpp::NumericVector> InnerBall = R_NilValue,
+               Rcpp::Nullable<std::string> Algo = R_NilValue,
+               Rcpp::Nullable<std::string> WalkType = R_NilValue,
+               Rcpp::Nullable<bool> rounding = R_NilValue,
+               Rcpp::Nullable<Rcpp::List> Parameters = R_NilValue,
+               Rcpp::Nullable<Rcpp::NumericMatrix> A = R_NilValue,
+               Rcpp::Nullable<Rcpp::NumericVector> b = R_NilValue,
+               Rcpp::Nullable<Rcpp::NumericMatrix> Aeq = R_NilValue,
+               Rcpp::Nullable<Rcpp::NumericVector> beq = R_NilValue) {
 
     typedef double NT;
     typedef Cartesian<NT>    Kernel;

--- a/include/volume/low_dimensional.h
+++ b/include/volume/low_dimensional.h
@@ -1,0 +1,33 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 20012-2018 Vissarion Fisikopoulos
+// Copyright (c) 2018 Apostolos Chalkis
+
+#ifndef LOW_DIMENSIONAL_H
+#define LOW_DIMENSIONAL_H
+
+template <class Polytope, class MT, class VT>
+std::pair<Polytope, VT> get_low_dimensional_poly(MT A, VT b, MT Aeq, VT beq, MT &W) {
+
+    typedef typename Polytope::NT 	NT;
+    Polytope HP;
+    int m = Aeq.rows(), n = Aeq.cols();
+
+    VT x = Aeq.fullPivLu().solve(beq);
+    b = b - A*x;
+
+    Eigen::JacobiSVD<MT> svd(Aeq.transpose(), Eigen::ComputeFullU | Eigen::ComputeFullV);
+    MT T2 = svd.matrixU().transpose();
+
+    W.resize(n,n-m);
+    for (int i = 0; i < n-m; ++i) {
+        W.col(i) = T2.col(m+i);
+    }
+
+    MT A2 = A*W;
+    HP.init(n-m, A2, b);
+    return std::pair<Polytope, VT>(HP,x);
+
+}
+
+#endif


### PR DESCRIPTION
Given `n+1` inequalities and `k` equalities in `R^n` the implementation defines the H-polytope in `R^{n-k}` and computes its volume or samples uniform points from it. 

If sampling is requested we sample in `R^{n-k}` and map the points to `R^n`

The implementation is available only for the R package. The C++ code is exposed through `sample_points()` function in `/R-proj/src/sample_points.cpp`.

Only uniform sampling is available. Otherwise we issue a warning.