### PR TITLE
Fix the bug in the equality operator of the point class

### DIFF
--- a/include/cartesian_geom/point.h
+++ b/include/cartesian_geom/point.h
@@ -92,9 +92,10 @@ public:
 
         typename Coeff::iterator pit = p.iter_begin();
         typename Coeff::iterator mit = coeffs.begin();
+        FT e = 0.00000000001;
 
         for ( ;  pit!=p.iter_end(); ++pit, ++mit) {
-            if (*mit!=*pit) return false;
+            if (std::abs(*mit - *pit)> e*std::abs(*mit) || std::abs(*mit - *pit)> e*std::abs(*pit) ) return false;
         }
 
         return true;


### PR DESCRIPTION
Fix the equality operator of a point.
To check if two doubles are equal we follow "The art of computer programming" (vol II), p. 234, Donald. E. Knuth.