### PR TITLE
add ellipsoid walks: Dikin, John and Vaidya walk.

### DIFF
--- a/R-proj/src/Makevars
+++ b/R-proj/src/Makevars
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS=-I../../external/boost -I../../external/LPsolve_src/run_headers -I../../external/minimum_ellipsoid -I../../include -I../../include/volume -I../../include/generators -I../../include/samplers -I../../include/annealing -I../../include/convex_bodies
+PKG_CPPFLAGS=-I../../external/boost -I../../external/LPsolve_src/run_headers -I../../external/minimum_ellipsoid -I../../include -I../../include/volume -I../../include/generators -I../../include/samplers -I../../include/samplers/ellipsoid_walks -I../../include/annealing -I../../include/convex_bodies
 PKG_CXXFLAGS= -lm -ldl -Wno-ignored-attributes -DBOOST_NO_AUTO_PTR
 CXX_STD = CXX11
 

--- a/R-proj/src/Makevars.win
+++ b/R-proj/src/Makevars.win
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS=-I../../external/boost -I../../external/LPsolve_src/run_headers -I../../external/minimum_ellipsoid -I../../include -I../../include/volume -I../../include/generators -I../../include/samplers -I../../include/annealing -I../../include/convex_bodies
+PKG_CPPFLAGS=-I../../external/boost -I../../external/LPsolve_src/run_headers -I../../external/minimum_ellipsoid -I../../include -I../../include/volume -I../../include/generators -I../../include/samplers -I../../include/samplers/ellipsoid_walks -I../../include/annealing -I../../include/convex_bodies
 PKG_CXXFLAGS= -lm -ldl -Wno-ignored-attributes -DBOOST_NO_AUTO_PTR
 CXX_STD = CXX11
 

--- a/R-proj/src/sample_points.cpp
+++ b/R-proj/src/sample_points.cpp
@@ -45,6 +45,9 @@
 //' \item{\code{dimension} }{ An integer that declares the dimension when exact sampling is enabled for a simplex or a hypersphere.}
 //' \item{\code{radius} }{ The radius of the \eqn{d}-dimensional hypersphere. The default value is \eqn{1}.}
 //' \item{\code{BW_rad} }{ The radius for the ball walk.}
+//' \item{\code{Dikin} }{Dikin walk}
+//' \item{\code{John} }{John walk}
+//' \item{\code{Vaidya} }{Vaidya walk}
 //' }
 //' @param InnerPoint A \eqn{d}-dimensional numerical vector that defines a point in the interior of polytope P.
 //'

--- a/include/cartesian_geom/point.h
+++ b/include/cartesian_geom/point.h
@@ -45,6 +45,10 @@ public:
     void set_coord(const unsigned int i, FT coord) {
         coeffs[i] = coord;
     }
+
+    Coeff get_coeffs() {
+        return coeffs;
+    }
     
     FT operator[] (const unsigned int i) {
         return coeffs[i];

--- a/include/convex_bodies/polytopes.h
+++ b/include/convex_bodies/polytopes.h
@@ -390,6 +390,18 @@ public:
     }
 
 
+    void normalize() {
+
+        NT row_norm;
+        for (int i = 0; i < num_of_hyperplanes(); ++i) {
+            row_norm = A.row(i).norm();
+            A.row(i) = A.row(i) / row_norm;
+            b(i) = b(i) / row_norm;
+        }
+
+    }
+
+
     // Apply linear transformation, of square matrix T^{-1}, in H-polytope P:= Ax<=b
     void linear_transformIt(MT T) {
         A = A * T;

--- a/include/samplers/ellipsoid_walks/dikin_walker.h
+++ b/include/samplers/ellipsoid_walks/dikin_walker.h
@@ -1,12 +1,6 @@
-// VolEsti (volume computation and sampling library)
+// Code from https://github.com/rzrsk/vaidya-walk
 
-// Copyright (c) 2012-2019 Vissarion Fisikopoulos
-
-// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
-
-//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
-
-// Licensed under GNU LGPL.3, see LICENCE file
+// Modified by Apostolos Chalkis, as part of Google Summer of Code 2019 program.
 
 #ifndef PWALK_DIKIN_WALKER_HPP_
 #define PWALK_DIKIN_WALKER_HPP_

--- a/include/samplers/ellipsoid_walks/dikin_walker.h
+++ b/include/samplers/ellipsoid_walks/dikin_walker.h
@@ -1,0 +1,99 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 2012-2019 Vissarion Fisikopoulos
+
+// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
+
+//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
+
+// Licensed under GNU LGPL.3, see LICENCE file
+
+#ifndef PWALK_DIKIN_WALKER_HPP_
+#define PWALK_DIKIN_WALKER_HPP_
+
+#include <Eigen/Dense>
+#include "math_functions.h"
+#include "walker.h"
+
+//namespace pwalk {
+
+template <typename Dtype>
+class DikinWalker: public Walker<Dtype> {
+public:
+    DikinWalker(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& initialization, const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& cons_A, const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& cons_b, const Dtype r) : Walker<Dtype>(initialization, cons_A, cons_b), r_(r){}
+
+    // getter for radius
+    Dtype getRadius() {
+        return r_;
+    }
+
+    void proposal(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+        Eigen::Matrix<Dtype, Eigen::Dynamic, 1> gaussian_step = Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Zero(this->nb_dim_);
+        sample_gaussian<Dtype>(this->nb_dim_, 0., 1., gaussian_step);
+
+        // get hessian
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+        sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess);
+
+        new_sample = this->curr_sample_ + r_ / std::sqrt(Dtype(this->nb_dim_))  * (new_sqrt_inv_hess * gaussian_step);
+    }
+
+    bool acceptRejectReverse(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+        // get hessian on x
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_x = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+        sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess_x);
+        // get hessian on y
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_y = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+        sqrtInvHessBarrier(new_sample, new_sqrt_inv_hess_y);
+
+        Dtype scale = r_/std::sqrt(Dtype(this->nb_dim_));
+        Dtype p_y_to_x = gaussian_density<Dtype>(this->curr_sample_, new_sample, new_sqrt_inv_hess_y.inverse()/scale);
+        Dtype p_x_to_y = gaussian_density<Dtype>(new_sample, this->curr_sample_, new_sqrt_inv_hess_x.inverse()/scale);
+
+        Dtype ar_ratio = std::min<Dtype>(1., p_y_to_x/p_x_to_y);
+
+        Dtype random_num = rng_uniform<Dtype>(0., 1.);
+        // lazy version of the walk
+        if (random_num > ar_ratio) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool doSample(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, const Dtype lazy = Dtype(0.5)){
+        proposal(new_sample);
+        this->nb_curr_samples_ += 1;
+        // for lazy markov chain
+        Dtype random_num = rng_uniform<Dtype>(0., 1.);
+        // check balance and check in polytope
+        if (random_num < lazy && this->checkInPolytope(new_sample) && acceptRejectReverse(new_sample)){
+            this->curr_sample_ = new_sample;
+            return true;
+        } else {
+            new_sample = this->curr_sample_;
+            return false;
+        }
+    }
+
+    void sqrtInvHessBarrier(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& new_sqrt_inv_hess){
+        Eigen::Matrix<Dtype, Eigen::Dynamic, 1> inv_slack = (this->cons_b_ - this->cons_A_ * new_sample).cwiseInverse();
+
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> half_hess = inv_slack.asDiagonal()* this->cons_A_;
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_hess = half_hess.transpose() * half_hess;
+
+        // compute eigenvectors and eigenvalues
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> > es(new_hess);
+
+        Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> V = es.eigenvectors();
+        Eigen::Matrix<Dtype, Eigen::Dynamic, 1> Dv = es.eigenvalues();
+        new_sqrt_inv_hess = V * Dv.cwiseInverse().cwiseSqrt().asDiagonal() * V.transpose();
+    }
+
+private:
+    const Dtype r_;
+};
+
+//} // namespace pwalk
+
+#endif // PWALK_DIKIN_WALKER_HPP_

--- a/include/samplers/ellipsoid_walks/john_walker.h
+++ b/include/samplers/ellipsoid_walks/john_walker.h
@@ -1,12 +1,6 @@
-// VolEsti (volume computation and sampling library)
+// Code from https://github.com/rzrsk/vaidya-walk
 
-// Copyright (c) 2012-2019 Vissarion Fisikopoulos
-
-// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
-
-//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
-
-// Licensed under GNU LGPL.3, see LICENCE file
+// Modified by Apostolos Chalkis, as part of Google Summer of Code 2019 program.
 
 #ifndef PWALK_JOHN_WALKER_HPP_
 #define PWALK_JOHN_WALKER_HPP_

--- a/include/samplers/ellipsoid_walks/john_walker.h
+++ b/include/samplers/ellipsoid_walks/john_walker.h
@@ -1,0 +1,140 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 2012-2019 Vissarion Fisikopoulos
+
+// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
+
+//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
+
+// Licensed under GNU LGPL.3, see LICENCE file
+
+#ifndef PWALK_JOHN_WALKER_HPP_
+#define PWALK_JOHN_WALKER_HPP_
+
+#include <cmath>
+#include <Eigen/Dense>
+#include "math_functions.h"
+#include "walker.h"
+
+//namespace pwalk {
+
+template <typename Dtype>
+class JohnWalker: public Walker<Dtype> {
+public:
+  JohnWalker(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& initialization, const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& cons_A, const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& cons_b, const Dtype r) : Walker<Dtype>(initialization, cons_A, cons_b), r_(r), alpha_(1. - 1. / std::log2(2.*Dtype(cons_A.rows())/Dtype(cons_A.cols()))), beta_(Dtype(cons_A.cols())/2./Dtype(cons_A.rows())), curr_weight_(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Ones(cons_A.rows())){}
+
+  // getter for radius
+  Dtype getRadius() {
+    return r_;
+  }
+
+  void proposal(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> gaussian_step = Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Zero(this->nb_dim_);
+      sample_gaussian<Dtype>(this->nb_dim_, 0., 1., gaussian_step);
+
+      // get hessian
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+      sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess);
+
+      new_sample = this->curr_sample_ + r_ / std::sqrt(Dtype(this->nb_dim_))  * (new_sqrt_inv_hess * gaussian_step);
+  }
+
+  bool acceptRejectReverse(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+      // get hessian on y
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_y = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+      sqrtInvHessBarrier(new_sample, new_sqrt_inv_hess_y);
+      // get hessian on x
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_x = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+      sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess_x);
+
+      Dtype scale = r_ / std::sqrt(Dtype(this->nb_dim_));
+      Dtype p_y_to_x = gaussian_density<Dtype>(this->curr_sample_, new_sample, new_sqrt_inv_hess_y.inverse()/scale);
+      Dtype p_x_to_y = gaussian_density<Dtype>(new_sample, this->curr_sample_, new_sqrt_inv_hess_x.inverse()/scale);
+
+      Dtype ar_ratio = std::min<Dtype>(1., p_y_to_x/p_x_to_y);
+
+      Dtype random_num = rng_uniform<Dtype>(0., 1.);
+      // lazy version of the walk
+      if (random_num > ar_ratio) {
+          return false;
+      }
+
+      return true;
+  }
+
+  bool doSample(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, const Dtype lazy = Dtype(0.5)){
+      proposal(new_sample);
+      this->nb_curr_samples_ += 1;
+      // for lazy markov chain
+      Dtype random_num = rng_uniform<Dtype>(0., 1.);
+      // check balance and check in polytope
+      if (random_num < lazy && this->checkInPolytope(new_sample) && acceptRejectReverse(new_sample)){
+          this->curr_sample_ = new_sample;
+          return true;
+      } else {
+          new_sample = this->curr_sample_;
+          return false;
+      }
+  }
+
+  void sqrtInvHessBarrier(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& new_sqrt_inv_hess){
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> inv_slack = (this->cons_b_ - this->cons_A_ * new_sample).cwiseInverse();
+
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> half_hess = inv_slack.asDiagonal()* this->cons_A_;
+
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> gradient;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> score;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> weight_half_alpha;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> weight_half_hess;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_hess;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_hess_inv;
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> beta_ones = beta_ * Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Ones(this->nb_cons_);
+
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> next_weight = curr_weight_;
+      // compute scores using gradient descent
+      do {
+          curr_weight_ = next_weight;
+          weight_half_alpha = curr_weight_.array().pow(alpha_/2.);
+
+          weight_half_hess = (weight_half_alpha.cwiseProduct(inv_slack)).asDiagonal() * this->cons_A_ ;
+
+          new_hess = weight_half_hess.transpose() * weight_half_hess;
+
+          new_hess_inv = new_hess.inverse();
+
+          score = ((weight_half_hess * new_hess_inv).cwiseProduct(weight_half_hess)).rowwise().sum();
+
+          // gradient = Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Ones(this->nb_cons_) - (score + beta_ones).cwiseQuotient(curr_weight_);
+
+          // curr_weight_ = (curr_weight_ - 0.5 * gradient).cwiseMax(beta_ones);
+          next_weight = (0.5*(curr_weight_ + score + beta_ones)).cwiseMax(beta_ones);
+
+      } while ((next_weight - curr_weight_).template lpNorm<Eigen::Infinity>() > Dtype(0.00001));
+
+      // std::cout << "inv_slack" << inv_slack.transpose() << std::endl;
+      // std::cout << "score" << score.transpose() << std::endl;
+      // std::cout << "curr_weight_ " << curr_weight_.transpose() << std::endl;
+
+      // compute john hessian
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> john_new_hess = half_hess.transpose() * curr_weight_.asDiagonal() * half_hess;
+
+      // compute eigenvectors and eigenvalues
+      Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> > es(john_new_hess);
+
+      Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> V = es.eigenvectors();
+      Eigen::Matrix<Dtype, Eigen::Dynamic, 1> Dv = es.eigenvalues();
+      new_sqrt_inv_hess = V * Dv.cwiseInverse().cwiseSqrt().asDiagonal() * V.transpose();
+  }
+
+private:
+  const Dtype r_;
+  const Dtype alpha_;
+  const Dtype beta_;
+
+  Eigen::Matrix<Dtype, Eigen::Dynamic, 1> curr_weight_;
+};
+
+//} // namespace pwalk
+
+#endif // PWALK_JOHN_WALKER_HPP_
+

--- a/include/samplers/ellipsoid_walks/math_functions.h
+++ b/include/samplers/ellipsoid_walks/math_functions.h
@@ -1,12 +1,6 @@
-// VolEsti (volume computation and sampling library)
+// Code from https://github.com/rzrsk/vaidya-walk
 
-// Copyright (c) 2012-2019 Vissarion Fisikopoulos
-
-// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
-
-//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
-
-// Licensed under GNU LGPL.3, see LICENCE file
+// Modified by Apostolos Chalkis, as part of Google Summer of Code 2019 program.
 
 
 #ifndef PWALK_UTIL_MATH_FUNCTIONS_HPP_

--- a/include/samplers/ellipsoid_walks/math_functions.h
+++ b/include/samplers/ellipsoid_walks/math_functions.h
@@ -1,0 +1,54 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 2012-2019 Vissarion Fisikopoulos
+
+// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
+
+//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
+
+// Licensed under GNU LGPL.3, see LICENCE file
+
+
+#ifndef PWALK_UTIL_MATH_FUNCTIONS_HPP_
+#define PWALK_UTIL_MATH_FUNCTIONS_HPP_
+
+#include <Eigen/Dense>
+#include <boost/random.hpp>
+#include <cmath>
+
+//namespace pwalk {
+
+// Define random number generator type
+typedef boost::mt19937 rng_t;
+
+template <typename Dtype>
+void sample_gaussian(const int n, const Dtype a,
+                     const Dtype sigma, Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& r) {
+    static rng_t gen(1234567);
+    static boost::normal_distribution<Dtype> random_distribution(a, sigma);
+    static boost::variate_generator<rng_t&, boost::normal_distribution<Dtype> >
+    variate_generator(gen, random_distribution);
+
+    for (int i = 0; i < n; ++i) {
+        r[i] = variate_generator();
+    }
+}
+
+template <typename Dtype>
+Dtype rng_uniform(const Dtype a, const Dtype b) {
+    static rng_t gen(1234567);
+    static boost::uniform_real<Dtype> random_distribution(a, b);
+    static boost::variate_generator<rng_t&, boost::uniform_real<Dtype> >
+    variate_generator(gen, random_distribution);
+
+    return variate_generator();
+}
+
+template <typename Dtype>
+Dtype gaussian_density(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& x, const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& mu, const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& sqrt_cov) {
+    Eigen::Matrix<Dtype, Eigen::Dynamic, 1> c = sqrt_cov * (x - mu);
+    return std::exp(-0.5*c.dot(c)) * sqrt_cov.determinant();
+}
+
+
+#endif // PWALK_UTIL_MATH_FUNTIONS_HPP_

--- a/include/samplers/ellipsoid_walks/vaidya_walker.h
+++ b/include/samplers/ellipsoid_walks/vaidya_walker.h
@@ -1,0 +1,109 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 2012-2019 Vissarion Fisikopoulos
+
+// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
+
+//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
+
+// Licensed under GNU LGPL.3, see LICENCE file
+
+#ifndef PWALK_VAIDYA_WALKER_HPP_
+#define PWALK_VAIDYA_WALKER_HPP_
+
+#include <Eigen/Dense>
+#include "math_functions.h"
+#include "walker.h"
+
+//namespace pwalk {
+
+template <typename Dtype>
+class VaidyaWalker: public Walker<Dtype> {
+public:
+  VaidyaWalker(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& initialization, const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& cons_A, const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& cons_b, const Dtype r) : Walker<Dtype>(initialization, cons_A, cons_b), r_(r){}
+
+  // getter for radius
+  Dtype getRadius() {
+    return r_;
+  }
+
+  void proposal(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+    Eigen::Matrix<Dtype, Eigen::Dynamic, 1> gaussian_step = Eigen::Matrix<Dtype, Eigen::Dynamic, 1>::Zero(this->nb_dim_);
+    sample_gaussian<Dtype>(this->nb_dim_, 0., 1., gaussian_step);
+
+    // get hessian
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+    sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess);
+
+    new_sample = this->curr_sample_ + r_ / std::sqrt(std::sqrt(Dtype(this->nb_dim_)*Dtype(this->nb_cons_)))  * (new_sqrt_inv_hess * gaussian_step);
+  }
+
+  bool acceptRejectReverse(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+    // get hessian on x
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_x = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+    sqrtInvHessBarrier(this->curr_sample_, new_sqrt_inv_hess_x);
+    // get hessian on y
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_sqrt_inv_hess_y = Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>::Zero(this->nb_dim_, this->nb_dim_);
+    sqrtInvHessBarrier(new_sample, new_sqrt_inv_hess_y);
+
+    Dtype scale = r_ / std::sqrt(std::sqrt(Dtype(this->nb_dim_)*Dtype(this->nb_cons_)));
+    Dtype p_y_to_x = gaussian_density<Dtype>(this->curr_sample_, new_sample, new_sqrt_inv_hess_y.inverse()/scale);
+    Dtype p_x_to_y = gaussian_density<Dtype>(new_sample, this->curr_sample_, new_sqrt_inv_hess_x.inverse()/scale);
+
+    Dtype ar_ratio = std::min<Dtype>(1., p_y_to_x/p_x_to_y);
+
+    Dtype random_num = rng_uniform<Dtype>(0., 1.);
+    // lazy version of the walk
+    if (random_num > ar_ratio) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool doSample(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, const Dtype lazy = Dtype(0.5)){
+    proposal(new_sample);
+    this->nb_curr_samples_ += 1;
+    // for lazy markov chain
+    Dtype random_num = rng_uniform<Dtype>(0., 1.);
+    // check balance and check in polytope
+    if (random_num < lazy && this->checkInPolytope(new_sample) && acceptRejectReverse(new_sample)){
+      this->curr_sample_ = new_sample;
+      return true;
+    } else {
+      new_sample = this->curr_sample_;
+      return false;
+    }
+  }
+
+  void sqrtInvHessBarrier(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& new_sqrt_inv_hess){
+    Eigen::Matrix<Dtype, Eigen::Dynamic, 1> inv_slack = (this->cons_b_ - this->cons_A_ * new_sample).cwiseInverse();
+
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> half_hess = inv_slack.asDiagonal()* this->cons_A_;
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_hess = half_hess.transpose() * half_hess;
+
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> new_hess_inv = new_hess.inverse();
+
+    // compute leverage scores
+    // Eigen::Matrix<Dtype, Eigen::Dynamic, 1> score  = ((this->cons_A_ * new_hess_inv).cwiseProduct(this->cons_A_)).rowwise().sum().cwiseProduct(inv_slack).cwiseProduct(inv_slack);
+    Eigen::Matrix<Dtype, Eigen::Dynamic, 1> score  = ((half_hess * new_hess_inv).cwiseProduct(half_hess)).rowwise().sum();
+
+    // compute vaidya hessian
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> vaidya_new_hess = half_hess.transpose() * score.asDiagonal() * half_hess + Dtype(this->nb_dim_)/Dtype(this->nb_cons_) * new_hess;
+
+    // compute eigenvectors and eigenvalues
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> > es(vaidya_new_hess);
+
+    Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic> V = es.eigenvectors();
+    Eigen::Matrix<Dtype, Eigen::Dynamic, 1> Dv = es.eigenvalues();
+    new_sqrt_inv_hess = V * Dv.cwiseInverse().cwiseSqrt().asDiagonal() * V.transpose();
+  }
+
+private:
+  const Dtype r_;
+};
+
+//} // namespace pwalk
+
+#endif // PWALK_VAIDYA_WALKER_HPP_
+

--- a/include/samplers/ellipsoid_walks/vaidya_walker.h
+++ b/include/samplers/ellipsoid_walks/vaidya_walker.h
@@ -1,12 +1,6 @@
-// VolEsti (volume computation and sampling library)
+// Code from https://github.com/rzrsk/vaidya-walk
 
-// Copyright (c) 2012-2019 Vissarion Fisikopoulos
-
-// Copyright (c) 2018-2019 Vissarion Fisikopoulos, Apostolos Chalkis
-
-//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018 program.
-
-// Licensed under GNU LGPL.3, see LICENCE file
+// Modified by Apostolos Chalkis, as part of Google Summer of Code 2019 program.
 
 #ifndef PWALK_VAIDYA_WALKER_HPP_
 #define PWALK_VAIDYA_WALKER_HPP_

--- a/include/samplers/ellipsoid_walks/walker.h
+++ b/include/samplers/ellipsoid_walks/walker.h
@@ -1,0 +1,61 @@
+#ifndef PWALK_WALK_HPP_
+#define PWALK_WALK_HPP_
+
+#include <Eigen/Dense>
+//#include "common.h"
+
+//namespace pwalk {
+
+template <typename Dtype>
+class Walker {
+public:
+  Walker(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& initialization, const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& cons_A, const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& cons_b) : nb_dim_(cons_A.cols()), nb_cons_(cons_A.rows()), nb_curr_samples_(1), initialization_(initialization), cons_A_(cons_A), cons_b_(cons_b), curr_sample_(initialization){}
+
+  virtual ~Walker(){}
+
+  virtual bool doSample(Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample, Dtype lazy = Dtype(0.5)){
+    return false;
+  }
+
+  // check whether a given point is in th polytope
+  bool checkInPolytope(const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& new_sample){
+    return (cons_A_ * new_sample - cons_b_).maxCoeff() < 0;
+  }
+
+  // getter for dimension
+  int getNbDim() {
+    return nb_dim_;
+  }
+
+  // getter for nb current samples
+  int getNbCurrSamples() {
+    return nb_curr_samples_;
+  }
+
+  // getter for current sample
+  Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& getCurrSample() {
+    return curr_sample_;
+  }
+
+protected:
+
+  // Dimension
+  const int nb_dim_;
+  // number of constraints
+  const int nb_cons_;
+  // current sample size
+  int nb_curr_samples_;
+  // Initial vector
+  const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& initialization_;
+  // constraints matrix A
+  const Eigen::Matrix<Dtype, Eigen::Dynamic, Eigen::Dynamic>& cons_A_;
+  // constraint vector b
+  const Eigen::Matrix<Dtype, Eigen::Dynamic, 1>& cons_b_;
+  // Current vector
+  Eigen::Matrix<Dtype, Eigen::Dynamic, 1> curr_sample_;
+};
+
+
+//} // namespace pwalk
+
+#endif // PWALK_WALK_HPP_

--- a/include/samplers/ellipsoid_walks/walker.h
+++ b/include/samplers/ellipsoid_walks/walker.h
@@ -1,3 +1,7 @@
+// Code from https://github.com/rzrsk/vaidya-walk
+
+// Modified by Apostolos Chalkis, as part of Google Summer of Code 2019 program.
+
 #ifndef PWALK_WALK_HPP_
 #define PWALK_WALK_HPP_
 


### PR DESCRIPTION
This PR contains three geometric random walks for uniform sampling from a convex polytope when the latter is given in H-representation:

- Dikin walk
- John walk
- Vaidya walk

We add the implementations from https://github.com/rzrsk/vaidya-walk and we make changes in order to be used efficiently from volesti package.