### PR TITLE
Readme correction and -help error in generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ which returns 17 numbers:
   
 To use CoolingGaussian (CG) algorithm run the following command:  
 ```
-./vol -f1 cube_10.ine -CG  
+./vol -f1 cube_10.ine -cg  
 ```
 which returns the same output as before.  
 

--- a/test/generator.cpp
+++ b/test/generator.cpp
@@ -228,7 +228,7 @@ int main(const int argc, const char** argv) {
 
         if (correct == false) {
             std::cerr << "unknown parameters \'" << argv[i] <<
-                      "\', try " << argv[0] << " --help" << std::endl;
+                      "\', try " << argv[0] << " -help" << std::endl;
             exit(-2);
         }
 


### PR DESCRIPTION
There are two issues.

First, is a simple README error, where the command for CoolingGaussian algorithm is given as -CG, but in the code it is given as -cg while checking parameters in vol.cpp.

Second, while in generator.cpp the help can be printed using -help as in the code, when a wrong parameter is given, it gives out to check --help, which is wrong in itself.

Screenshot:

![Error](https://user-images.githubusercontent.com/11738485/75884504-f50bbf00-5e4a-11ea-90d1-f9a7ff543006.png)
 