### PR TITLE
Fix bug in hpolytope print function

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -168,12 +168,12 @@ public:
     // print polytope in input format
     void print() {
 #ifdef VOLESTI_DEBUG
-        std::cout << " " << A.rows() << " " << _d + 1 << " float" << std::endl;
+        std::cout << " " << A.rows() << " " << _d << " float" << std::endl;
 #endif
         for (unsigned int i = 0; i < A.rows(); i++) {
             for (unsigned int j = 0; j < _d; j++) {
                 #ifdef VOLESTI_DEBUG
-                std::cout << -A(i, j) << " ";
+                std::cout << A(i, j) << " ";
                 #endif
             }
             #ifdef VOLESTI_DEBUG


### PR DESCRIPTION
This fixes the erroneous output of the hpolytope.print function.