### PR TITLE
Reuse PRNG in get_point_in/on_Dsphere

### DIFF
--- a/include/samplers/samplers.h
+++ b/include/samplers/samplers.h
@@ -13,14 +13,11 @@
 
 // Pick a random direction as a normilized vector
 template <typename RNGType, typename Point, typename NT>
-Point get_direction(const unsigned int dim) {
+Point get_direction(const unsigned int dim, RNGType& rng) {
 
     boost::normal_distribution<> rdist(0,1);
     std::vector<NT> Xs(dim,0);
     NT normal = NT(0);
-    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-    RNGType rng(seed);
-    //RNGType rng2 = var.rng;
     for (unsigned int i=0; i<dim; i++) {
         Xs[i] = rdist(rng);
         normal += Xs[i] * Xs[i];
@@ -37,8 +34,8 @@ Point get_direction(const unsigned int dim) {
 
 // Pick a random point from a d-sphere
 template <typename RNGType, typename Point, typename NT>
-Point get_point_on_Dsphere(const unsigned int dim, const NT &radius){
-    Point p = get_direction<RNGType, Point, NT>(dim);
+Point get_point_on_Dsphere(const unsigned int dim, const NT &radius, RNGType& rng){
+  Point p = get_direction<RNGType, Point, NT>(dim, rng);
     p = (radius == 0) ? p : radius * p;
     return p;
 }
@@ -46,14 +43,12 @@ Point get_point_on_Dsphere(const unsigned int dim, const NT &radius){
 
 // Pick a random point from a d-ball
 template <typename RNGType, typename Point, typename NT>
-Point get_point_in_Dsphere(const unsigned int dim, const NT &radius){
+Point get_point_in_Dsphere(const unsigned int dim, const NT &radius, RNGType& rng){
 
     boost::random::uniform_real_distribution<> urdist(0,1);
     NT U;
-    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-    RNGType rng2(seed);
-    Point p = get_direction<RNGType, Point, NT>(dim);
-    U = urdist(rng2);
+    Point p = get_direction<RNGType, Point, NT>(dim, rng);
+    U = urdist(rng);
     U = std::pow(U, 1.0/(NT(dim)));
     p = (radius*U)*p;
     return p;


### PR DESCRIPTION
## Description

Changes `get_direction` and `get_point_[on/in]_Dsphere` not to initialize a new PRNG in every call. The objective is to improve performance of ball walk algorithms, that call this function many times.

In my experiments, PRNG initialization seemed to be very expensive. Applying this modification to [this ball walk](https://github.com/danipozo/uld-test-solutions/blob/master/c%2B%2B/medium.cpp) decreased runtime 26x.

### Needed changes

For this to be merged, all the tests and all the functions that use `get_direction` or `get_point_[on/in]_Dsphere` should be updated.

Another option would be to use a PRNG object with `static` storage, which wouldn't require any changes, however seems to be a bit slower in my experiments.